### PR TITLE
Hotfix/change email functionality

### DIFF
--- a/School/repository/school.sql
+++ b/School/repository/school.sql
@@ -1,0 +1,19 @@
+create table school
+(
+    id      text not null
+        constraint school_pkey
+            primary key,
+    name    text,
+    country text,
+    domains text[]
+);
+
+alter table school
+    owner to postgres;
+
+CREATE TABLE public.confirmation (
+    token text PRIMARY KEY NOT NULL,
+    st_id text not null REFERENCES student(id),
+    sc_id text not null REFERENCES school(id),
+    created_at timestamp
+);

--- a/School/usecase/school_usecase.go
+++ b/School/usecase/school_usecase.go
@@ -117,7 +117,10 @@ func (s *schoolUseCase) SendConfirmation(c context.Context, st *domain.Student, 
 func createEmailBody(name, school, url string) []byte {
 	t, err := template.ParseFiles("static/confirmation_template.html")
 	if err != nil {
-		log.Fatalln(err)
+		t, err = template.ParseFiles("../../static/confirmation_template.html")
+		if err != nil {
+			log.Fatal("no email confirmation template")
+		}
 	}
 	var body bytes.Buffer
 	mimeHeaders := "MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n"

--- a/School/usecase/school_usecase.go
+++ b/School/usecase/school_usecase.go
@@ -115,7 +115,7 @@ func (s *schoolUseCase) SendConfirmation(c context.Context, st *domain.Student, 
 }
 
 func createEmailBody(name, school, url string) []byte {
-	t, err := template.ParseFiles("../../static/confirmation_template.html")
+	t, err := template.ParseFiles("static/confirmation_template.html")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/app/urls.go
+++ b/app/urls.go
@@ -27,7 +27,7 @@ func mapSchoolURLs(m Middleware, h *schoolHttp.SchoolHandler, r *gin.Engine) {
 	authorized := r.Group("/api")
 	authorized.Use(m.AuthMiddleware())
 	authorized.GET("/school", h.SearchStudentSchool)
-	authorized.POST("/school/confirm", h.SendConfirmationMail)
+	authorized.GET("/school/confirm", h.SendConfirmationMail)
 }
 
 func mapTagURLs(h *tagHttp.TagHandler, r *gin.Engine) {

--- a/utils/mailer.go
+++ b/utils/mailer.go
@@ -13,24 +13,24 @@ type Mailer interface {
 // NewSimpleMail is a constructor for Mailer interface. Returns a simpleMail struct
 func NewSimpleMail() Mailer {
 	return simpleMail{
-		from:     os.Getenv("EMAIL"),
+		from:     os.Getenv("EMAIL_FROM"),
+		user:     os.Getenv("USER"),
 		password: os.Getenv("PASSWORD"),
-		smtpHost: "smtp.gmail.com",
-		smtpPort: "587",
+		smtpHost: os.Getenv("SMTP_HOST"),
+		smtpPort: os.Getenv("SMTP_PORT"),
 	}
 }
 
 type simpleMail struct {
 	from     string
+	user 	 string
 	password string
-	// smtp.gmail.com
 	smtpHost string
-	// 587
 	smtpPort string
 }
 
 // SendSimpleMail utilizes the golang smtp library to send a simple mail
 func (s simpleMail) SendSimpleMail(to string, body []byte) error {
-	auth := smtp.PlainAuth("Stud Pal", s.from, s.password, s.smtpHost)
+	auth := smtp.PlainAuth("Stud Pal", s.user, s.password, s.smtpHost)
 	return smtp.SendMail(s.smtpHost+":"+s.smtpPort, auth, s.from, []string{to}, body)
 }


### PR DESCRIPTION
Change the functionality of how user email confirmation works:
1. Make a request to `/school/confirm?email={email}`. If the email is not valid, you get an error. If the domain doesn't exist, you get an error. If the domain does exist for a school, an email is sent and the student school can be confirmed. If the domain is true for a list of schools, email is sent to the first one.
2. Changed the method to GET from POST.
3. The search school endpoint is still there, but it's usage is not necessary